### PR TITLE
Module help

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "rustircbot"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["David Reeve <nerdboy6@gmail.com>"]
 
 [dependencies.rustirc]

--- a/src/bot.rs
+++ b/src/bot.rs
@@ -3,17 +3,20 @@ use rustirc::info;
 use rustirc::message;
 
 use events;
+use help;
 
 pub struct Bot <'bl> {
   pub client : client::Client,
   pub events : events::EventDispatcher <'bl>,
+  pub help   : help::HelpHandler <'bl>,
 }
 
 impl <'bl> Bot <'bl> {
   pub fn connect <'a> ( host : &str, port : u16, pass : &str, info : Box < info::IrcInfo > ) -> Bot <'a> {
     Bot {
-      client : client::Client::connect( host, port, pass, info ),
+      client : client::Client::connect( host, port, pass, info.clone( ) ),
       events : events::EventDispatcher::new( ),
+      help   : help::HelpHandler::new( info.nick_name.as_slice( ), "", "" ),
     }
   }
   
@@ -24,6 +27,11 @@ impl <'bl> Bot <'bl> {
   
   fn handle_dispatch ( &mut self, msg : message::Message ) {
     self.events.handle_msg( msg, &mut self.client );
+  }
+  
+  pub fn init_help ( &'bl mut self, cmd : &str, nice : &str ) {
+    self.help.add_help( nice, "Provides help information for this bot." );
+    self.events.register_command( cmd, Box::new( self.help.clone( ) ) );
   }
   
   pub fn start ( mut self ) {

--- a/src/bot.rs
+++ b/src/bot.rs
@@ -2,6 +2,7 @@ use rustirc::client;
 use rustirc::info;
 use rustirc::message;
 
+use command;
 use events;
 use help;
 
@@ -29,9 +30,25 @@ impl <'bl> Bot <'bl> {
     self.events.handle_msg( msg, &mut self.client );
   }
   
+  pub fn add_help( &mut self, cmd : &str, help : &str ) {
+    self.help.add_help( cmd, help );
+  }
+  
   pub fn init_help ( &mut self, cmd : &str, nice : &str ) {
     self.help.add_help( nice, "Provides help information for this bot." );
     self.events.register_command( cmd, Box::new( self.help.clone( ) ) );
+  }
+  
+  pub fn add_cmd ( &mut self, patt : &str, cb : Box < command::Cmd + 'bl > ) {
+    self.events.register_command( patt, cb );
+  }
+  
+  pub fn add_raw_cmd ( &mut self, patt : &str, cb : Box < command::Cmd + 'bl > ) {
+    self.events.register_raw_command( patt, cb );
+  }
+  
+  pub fn add_code_cmd ( &mut self, code : &str, patt : &str, cb : Box < command::Cmd + 'bl > ) {
+    self.events.register_code_command( code, patt, cb );
   }
   
   pub fn set_help_info ( &mut self, name : &str, author : &str, version : &str ) {

--- a/src/bot.rs
+++ b/src/bot.rs
@@ -34,6 +34,12 @@ impl <'bl> Bot <'bl> {
     self.events.register_command( cmd, Box::new( self.help.clone( ) ) );
   }
   
+  pub fn set_help_info ( &mut self, name : &str, author : &str, version : &str ) {
+    self.help.info.name     = name.to_string( );
+    self.help.info.author   = author.to_string( );
+    self.help.info.version  = version.to_string( );
+  }
+  
   pub fn start ( mut self ) {
     let (rx,cnt)    = self.client.start_thread( );
     self.client     = cnt;

--- a/src/bot.rs
+++ b/src/bot.rs
@@ -29,7 +29,7 @@ impl <'bl> Bot <'bl> {
     self.events.handle_msg( msg, &mut self.client );
   }
   
-  pub fn init_help ( &'bl mut self, cmd : &str, nice : &str ) {
+  pub fn init_help ( &mut self, cmd : &str, nice : &str ) {
     self.help.add_help( nice, "Provides help information for this bot." );
     self.events.register_command( cmd, Box::new( self.help.clone( ) ) );
   }

--- a/src/bot.rs
+++ b/src/bot.rs
@@ -16,7 +16,7 @@ impl <'bl> Bot <'bl> {
     Bot {
       client : client::Client::connect( host, port, pass, info.clone( ) ),
       events : events::EventDispatcher::new( ),
-      help   : help::HelpHandler::new( info.nick_name.as_slice( ), "", "" ),
+      help   : help::HelpHandler::new( "Unnamed", "Someone", "0.0" ),
     }
   }
   

--- a/src/help.rs
+++ b/src/help.rs
@@ -6,7 +6,7 @@ use std::time::duration::Duration;
 
 use command;
 
-struct HelpInfo {
+pub struct HelpInfo {
   pub name    : String,
   pub author  : String,
   pub version : String,
@@ -23,7 +23,7 @@ impl Clone for HelpInfo {
 }
 
 pub struct HelpHandler <'hl> {
-  info        : HelpInfo,
+  pub info    : HelpInfo,
   helpmap     : collections::HashMap < String, Vec < String > >,
 }
 

--- a/src/help.rs
+++ b/src/help.rs
@@ -1,0 +1,118 @@
+use rustirc::client::Client;
+use rustirc::message::Message;
+use std::collections;
+use std::io::timer;
+use std::time::duration::Duration;
+
+use command;
+
+struct HelpInfo {
+  pub name    : String,
+  pub author  : String,
+  pub version : String,
+}
+
+impl Clone for HelpInfo {
+  fn clone ( &self ) -> HelpInfo {
+    HelpInfo {
+      name    : self.name.clone( ),
+      author  : self.author.clone( ),
+      version : self.version.clone( ),
+    }
+  }
+}
+
+pub struct HelpHandler <'hl> {
+  info        : HelpInfo,
+  helpmap     : collections::HashMap < String, Vec < String > >,
+}
+
+impl <'hl> HelpHandler <'hl> {
+  pub fn new <'a> ( name : &str, author : &str, version : &str ) -> HelpHandler <'a> {
+    HelpHandler {
+      info      : HelpInfo {
+        name    : name.to_string( ),
+        author  : author.to_string( ),
+        version : version.to_string( ),
+      },
+      helpmap   : collections::HashMap::new( ),
+    }
+  }
+
+  pub fn add_help( &mut self, cmd : &str, help : &str ) {
+    let mut helpvec : Vec < String > = Vec::new( );
+    for line in help.lines( ) {
+      helpvec.push( line.to_string( ) );
+    }
+    self.helpmap.insert( cmd.to_string( ), helpvec );
+  }
+}
+
+impl <'hl> Clone for HelpHandler <'hl> {
+  fn clone <'a> ( &self ) -> HelpHandler <'a> {
+    HelpHandler {
+      info    : self.info.clone( ),
+      helpmap : self.helpmap.clone( ),
+    }
+  }
+}
+
+impl <'hl> command::Cmd for HelpHandler <'hl> {
+  fn on_cmd( &mut self, msg : Message, cnt : &mut Client ) {
+    // get the nick of whoever asked for help
+    let targ = match msg.nick( ) {
+      Some( nick ) => nick,
+      None         => { return; },
+    };
+    
+    // extract our parameters
+    let params : Vec < &str > = msg.trailing( ).unwrap( ).words( ).collect( );
+    
+    // no command specified, print general help
+    if params.len( ) == 1 {
+      // give us a nice little header that shows the bot info
+      let headline = format! ( "{} by {} - Version {}", 
+        self.info.name, self.info.author, self.info.version );
+      cnt.message( targ.as_slice( ), headline.as_slice( ) );
+      
+      // print the basic help for each command
+      for (k,v) in self.helpmap.iter( ) {
+        sleep( 100 );
+        let helpline = format! ( "{} - {}", k, v[0] );
+        cnt.message( targ.as_slice( ), helpline.as_slice( ) );
+      }
+      
+    // commands given, print extended help
+    } else {
+      for i in range( 1, params.len( ) ) {
+        // check if the command exists
+        match self.helpmap.get( &String::from_str( params[i] ) ) {
+          Some( help ) => {
+            // print the command name
+            let headline = format! ( " - {}", params[i] );
+            cnt.message( targ.as_slice( ), headline.as_slice( ) );
+            
+            // print extended help
+            for line in help.iter( ) {
+              sleep( 100 );
+              cnt.message( targ.as_slice( ), line.as_slice( ) );
+            }
+          },
+          
+          // command not found
+          None         => {
+            let outline = format! ( "Command '{}' not found", params[i] );
+            cnt.message( targ.as_slice( ), outline.as_slice( ) );
+          },
+        }
+        
+        // sleep between commands
+        sleep( 100 );
+      }
+    }
+  }
+}
+
+fn sleep( ms : usize ) {
+  return
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ extern crate rustirc;
 pub mod bot;
 pub mod command;
 mod console;
+pub mod help;
 pub mod events;
 
 // #[test]


### PR DESCRIPTION
Adds help.rs, a new module that helps in building bot help output.

Example:

``` rust
// first we set the help info
// this is shown when the help command is used without a parameter
// it looks like "<name> by <author> - Version <version>"
bot.set_help_info( "My Bot", "Lancey", "1.0" );

// add some commands to the help output
// anything after a newline in the help text is only shown on extended help
// i.e. "!help !kickban" would show the aliases
bot.add_help( "!kickban", "Kicks and bans someone.\nAliases: !kb" );
bot.add_help( "!define", "Gets the definition of a word.\nUses dictionary.com for lookup" );
bot.add_help( "YouTube Parser", "Automatically looks up the name and duration of YouTube links" );

// this line will add a help command automatically populated with our help info
// the first param is the help command regex, the second param is how the help command appears
// in the help output itself
bot.init_help( "^!help", "!help" );
```

Adding the code above to the main function will send help info to a client when they type !help in a channel the bot is in.
